### PR TITLE
Can create references and add them to reference lists

### DIFF
--- a/src/main/java/ohtuhatut/controller/ReferenceController.java
+++ b/src/main/java/ohtuhatut/controller/ReferenceController.java
@@ -4,6 +4,7 @@ package ohtuhatut.controller;
 import ohtuhatut.domain.BookReference;
 import ohtuhatut.domain.Reference;
 import ohtuhatut.repository.BookReferenceRepository;
+import ohtuhatut.repository.ReferenceListRepository;
 import ohtuhatut.repository.ReferenceRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -27,37 +28,25 @@ public class ReferenceController {
     private ReferenceRepository referenceRepository;
     @Autowired
     private BookReferenceRepository bookReferenceRepository;
+    @Autowired
+    private ReferenceListRepository referenceListRepository;
 
     @RequestMapping(value = "/{id}", method = RequestMethod.GET)
-    public String getReference(Model model, @PathVariable Long id){
-        
-        model.addAttribute("reference", referenceRepository.findOne(id));
-
+    public String getReference(Model model, @PathVariable Long id){     
+        model.addAttribute("reference", referenceRepository.findOne(id));      
         return "reference";
     }
     
     @RequestMapping(value = "/new", method = RequestMethod.GET)
-    public String newReference(Model model){
-        Reference reference = new BookReference();
-        model.addAttribute("reference", reference);
-        
+    public String newReference(Model model){        
         return "reference_choose";
     }
     
     @RequestMapping(value = "/bookreferences/new", method = RequestMethod.GET)
-    public String newBookReference(Model model){
-        Reference reference = new BookReference();
-        model.addAttribute("reference", reference);
+    public String newBookReference(Model model){;
+        model.addAttribute("reference", new BookReference());
         
         return "reference_new";
-    }
-    
-    @RequestMapping(value = "/new", method = RequestMethod.POST)
-    public String newReferenceCreate(@ModelAttribute Reference reference, RedirectAttributes attr) {
-        referenceRepository.save(reference);
-        
-        attr.addAttribute("id", reference.getId());
-        return "redirect:/references/{id}";
     }
     
     @RequestMapping(value = "/bookreferences/new", method = RequestMethod.POST)

--- a/src/main/java/ohtuhatut/controller/ReferenceController.java
+++ b/src/main/java/ohtuhatut/controller/ReferenceController.java
@@ -1,8 +1,10 @@
 
 package ohtuhatut.controller;
 
+import ohtuhatut.domain.ArticleReference;
 import ohtuhatut.domain.BookReference;
 import ohtuhatut.domain.Reference;
+import ohtuhatut.repository.ArticleReferenceRepository;
 import ohtuhatut.repository.BookReferenceRepository;
 import ohtuhatut.repository.ReferenceListRepository;
 import ohtuhatut.repository.ReferenceRepository;
@@ -30,32 +32,54 @@ public class ReferenceController {
     private BookReferenceRepository bookReferenceRepository;
     @Autowired
     private ReferenceListRepository referenceListRepository;
+    @Autowired
+    private ArticleReferenceRepository articleReferenceRepository;
 
+    @RequestMapping(value = "/new", method = RequestMethod.GET)
+    public String newReference(Model model){        
+        return "reference_choose";
+    }
+    
+    // works for all kind of references
     @RequestMapping(value = "/{id}", method = RequestMethod.GET)
     public String getReference(Model model, @PathVariable Long id){     
         model.addAttribute("reference", referenceRepository.findOne(id));      
         return "reference";
     }
     
-    @RequestMapping(value = "/new", method = RequestMethod.GET)
-    public String newReference(Model model){        
-        return "reference_choose";
-    }
-    
+    // -------------- book references
     @RequestMapping(value = "/bookreferences/new", method = RequestMethod.GET)
     public String newBookReference(Model model){;
         model.addAttribute("reference", new BookReference());
-        
+        model.addAttribute("referenceType", "bookreferences");
         return "reference_new";
     }
     
     @RequestMapping(value = "/bookreferences/new", method = RequestMethod.POST)
     public String newBookReferenceCreate(@ModelAttribute BookReference reference, RedirectAttributes attr) {
-        bookReferenceRepository.save(reference);
+        bookReferenceRepository.save(reference);       
         
         attr.addAttribute("id", reference.getId());
         return "redirect:/references/{id}";
     }
+    // <-- book references
+    
+    // -------------- article references
+    @RequestMapping(value = "/articlereferences/new", method = RequestMethod.GET)
+    public String newArticleReference(Model model) {
+        model.addAttribute("reference", new ArticleReference());
+        model.addAttribute("referenceType", "articlereferences");
+        return "reference_new";
+    }
+    
+    @RequestMapping(value = "/articlereferences/new", method = RequestMethod.POST)
+    public String newArticleReferenceCreate(@ModelAttribute ArticleReference reference, RedirectAttributes attr) {
+        articleReferenceRepository.save(reference);
+       
+        attr.addAttribute("id", reference.getId());
+        return "redirect:/references/{id}";
+    }
+    // <-- article references
     
 }
 

--- a/src/main/java/ohtuhatut/controller/ReferenceController.java
+++ b/src/main/java/ohtuhatut/controller/ReferenceController.java
@@ -1,0 +1,75 @@
+
+package ohtuhatut.controller;
+
+import ohtuhatut.domain.BookReference;
+import ohtuhatut.domain.Reference;
+import ohtuhatut.repository.BookReferenceRepository;
+import ohtuhatut.repository.ReferenceRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+/**
+ * Controller for handling references
+ * 
+ * @author tuomokar
+ */
+@Controller
+@RequestMapping("/references")
+public class ReferenceController {
+    
+    @Autowired
+    private ReferenceRepository referenceRepository;
+    @Autowired
+    private BookReferenceRepository bookReferenceRepository;
+
+    @RequestMapping(value = "/{id}", method = RequestMethod.GET)
+    public String getReference(Model model, @PathVariable Long id){
+        
+        model.addAttribute("reference", referenceRepository.findOne(id));
+
+        return "reference";
+    }
+    
+    @RequestMapping(value = "/new", method = RequestMethod.GET)
+    public String newReference(Model model){
+        Reference reference = new BookReference();
+        model.addAttribute("reference", reference);
+        
+        return "reference_choose";
+    }
+    
+    @RequestMapping(value = "/bookreferences/new", method = RequestMethod.GET)
+    public String newBookReference(Model model){
+        Reference reference = new BookReference();
+        model.addAttribute("reference", reference);
+        
+        return "reference_new";
+    }
+    
+    @RequestMapping(value = "/new", method = RequestMethod.POST)
+    public String newReferenceCreate(@ModelAttribute Reference reference, RedirectAttributes attr) {
+        referenceRepository.save(reference);
+        
+        attr.addAttribute("id", reference.getId());
+        return "redirect:/references/{id}";
+    }
+    
+    @RequestMapping(value = "/bookreferences/new", method = RequestMethod.POST)
+    public String newBookReferenceCreate(@ModelAttribute BookReference reference, RedirectAttributes attr) {
+        bookReferenceRepository.save(reference);
+        
+        attr.addAttribute("id", reference.getId());
+        return "redirect:/references/{id}";
+    }
+    
+}
+
+
+
+   

--- a/src/main/java/ohtuhatut/controller/ReferenceListController.java
+++ b/src/main/java/ohtuhatut/controller/ReferenceListController.java
@@ -8,21 +8,23 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-import java.util.ArrayList;
-import java.util.List;
+import ohtuhatut.domain.Reference;
 import ohtuhatut.domain.ReferenceList;
 import ohtuhatut.repository.ReferenceListRepository;
+import ohtuhatut.repository.ReferenceRepository;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 /**
  * Controller class for ReferenceList page.
  *
- * Created by iilumme.
+ * @author iilumme
+ * @author tuomokar
  */
 
 @Controller
-@RequestMapping("/referencelist")
+@RequestMapping("/referencelists")
 public class ReferenceListController {
 
     @Autowired
@@ -30,11 +32,14 @@ public class ReferenceListController {
     
     @Autowired
     private ReferenceListService referenceListService;
+    
+    @Autowired
+    private ReferenceRepository referenceRepository;
 
     @RequestMapping(value = "/{id}", method = RequestMethod.GET)
     public String getReferenceList(Model model, @PathVariable Long id){
-
         model.addAttribute("referenceList", referenceListService.getReferenceList(id));
+        model.addAttribute("references", referenceRepository.findAll());
 
         return "referenceList";
     }
@@ -51,6 +56,23 @@ public class ReferenceListController {
         referenceListRepository.save(referenceList);
         
         attr.addAttribute("id", referenceList.getId().toString());
-        return "redirect:/referencelist/{id}";
+        return "redirect:/referencelists/{id}";
+    }
+    
+    @RequestMapping(value = "/{referenceListId}/references", method = RequestMethod.POST)
+    public String addReferenceToList(@PathVariable(value="referenceListId") Long id, 
+            @RequestParam(value="referenceId") Long referenceId,
+            RedirectAttributes redirectAttrs) {
+        
+        ReferenceList list = referenceListRepository.findOne(id);
+        Reference reference = referenceRepository.findOne(referenceId);
+        
+        list.getReferences().add(reference);
+        referenceListRepository.save(list);        
+        
+        redirectAttrs.addAttribute("id", id);
+        
+        return "redirect:/referencelists/{id}";
+        
     }
 }

--- a/src/main/java/ohtuhatut/domain/ArticleReference.java
+++ b/src/main/java/ohtuhatut/domain/ArticleReference.java
@@ -1,0 +1,45 @@
+
+package ohtuhatut.domain;
+
+import java.util.ArrayList;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+/**
+ * Article reference
+ * 
+ * Required fields: author, title, journal, year, volume
+ * Optional fields: number, pages, month, note, key
+ * 
+ * @author tuomokar
+ */
+
+@Table(name = "Reference")
+@DiscriminatorValue("article")
+@Entity
+public class ArticleReference extends Reference {
+    
+    public ArticleReference() {
+        fields = new ArrayList<>();
+        fields.add("author");
+        fields.add("title");
+        fields.add("journal");
+        fields.add("year");
+        fields.add("volume");
+    }
+    
+    public String getField(String field) {
+        if (field.equals("author")) {
+            return author;
+        } else if (field.equals("title")) {
+            return title;
+        } else if (field.equals("journal")) {
+            return journal;
+        } else if (field.equals("volume")) {
+            return volume;
+        }
+        
+        return "" + year;
+    }
+}

--- a/src/main/java/ohtuhatut/domain/BookReference.java
+++ b/src/main/java/ohtuhatut/domain/BookReference.java
@@ -3,6 +3,7 @@ package ohtuhatut.domain;
 import ohtuhatut.domain.Reference;
 
 import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
 import javax.persistence.Table;
 
 /**
@@ -15,5 +16,6 @@ import javax.persistence.Table;
  */
 @Table(name = "Reference")
 @DiscriminatorValue("book")
+@Entity
 public class BookReference extends Reference {
 }

--- a/src/main/java/ohtuhatut/domain/BookReference.java
+++ b/src/main/java/ohtuhatut/domain/BookReference.java
@@ -1,5 +1,6 @@
 package ohtuhatut.domain;
 
+import java.util.ArrayList;
 import ohtuhatut.domain.Reference;
 
 import javax.persistence.DiscriminatorValue;
@@ -18,4 +19,24 @@ import javax.persistence.Table;
 @DiscriminatorValue("book")
 @Entity
 public class BookReference extends Reference {
+    
+    public BookReference() {
+        fields = new ArrayList<>();
+        fields.add("author");
+        fields.add("title");
+        fields.add("publisher");
+        fields.add("year");
+    }
+    
+    public String getField(String field) {
+        if (field.equals("author")) {
+            return author;
+        } else if (field.equals("title")) {
+            return title;
+        } else if (field.equals("publisher")) {
+            return publisher;
+        }
+        
+        return "" + year;
+    }
 }

--- a/src/main/java/ohtuhatut/domain/Reference.java
+++ b/src/main/java/ohtuhatut/domain/Reference.java
@@ -1,9 +1,11 @@
 package ohtuhatut.domain;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
-import javax.persistence.DiscriminatorType;
 import javax.persistence.DiscriminatorValue;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.Inheritance;
 import javax.persistence.Table;
@@ -24,17 +26,41 @@ import org.springframework.data.jpa.domain.AbstractPersistable;
 @DiscriminatorOptions(force=true)
 @Table(name = "Reference")
 public class Reference extends AbstractPersistable<Long> {
-    // Author of the work
-    private String author;
+
+    protected String author;
+    protected String title;
+    protected String publisher;
+    protected Integer year;  
+    protected String journal;
+    protected String volume;
+     
+    @Column
+    @ElementCollection(targetClass=String.class)
+    protected List<String> fields;
     
-    // Title of the work
-    private String title;
-    
-    // Publisher's name
-    private String publisher;
-    
-    // The year of publication
-    private Integer year;
+    public List<String> getFields() {
+        return fields;
+    }
+
+    public void setJournal(String journal) {
+        this.journal = journal;
+    }
+
+    public void setVolume(String volume) {
+        this.volume = volume;
+    }
+
+    public void setFields(List<String> fields) {
+        this.fields = fields;
+    }
+
+    public String getJournal() {
+        return journal;
+    }
+
+    public String getVolume() {
+        return volume;
+    }
     
     public String getAuthor() {
         return author;
@@ -48,7 +74,7 @@ public class Reference extends AbstractPersistable<Long> {
         return title;
     }
 
-    public void setTitle(String title) {
+    public void setTitle(String title) {;
         this.title = title;
     }
 

--- a/src/main/java/ohtuhatut/repository/ArticleReferenceRepository.java
+++ b/src/main/java/ohtuhatut/repository/ArticleReferenceRepository.java
@@ -1,0 +1,16 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package ohtuhatut.repository;
+
+import ohtuhatut.domain.ArticleReference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ *
+ * @author tuomokar
+ */
+public interface ArticleReferenceRepository extends JpaRepository<ArticleReference, Long> {
+}

--- a/src/main/java/ohtuhatut/repository/BookReferenceRepository.java
+++ b/src/main/java/ohtuhatut/repository/BookReferenceRepository.java
@@ -1,0 +1,8 @@
+
+package ohtuhatut.repository;
+
+import ohtuhatut.domain.BookReference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookReferenceRepository extends JpaRepository<BookReference, Long> {
+}

--- a/src/main/java/ohtuhatut/repository/ReferenceRepository.java
+++ b/src/main/java/ohtuhatut/repository/ReferenceRepository.java
@@ -1,0 +1,15 @@
+
+package ohtuhatut.repository;
+
+import ohtuhatut.domain.Reference;
+import ohtuhatut.domain.ReferenceList;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for saving references
+ * 
+ * @author tuomokar
+ */
+public interface ReferenceRepository extends JpaRepository<Reference, Long>  {
+    
+}

--- a/src/main/resources/templates/reference.html
+++ b/src/main/resources/templates/reference.html
@@ -1,14 +1,12 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
     <head>
-        <title>TODO supply a title</title>
+        <title>References</title>
     </head>
     <body>
-        <div>
-            <h1 th:text="${reference.author}"></h1>   
-            <h1 th:text="${reference.title}"></h1>
-            <h1 th:text="${reference.publisher}"></h1>
-            <h1 th:text="${reference.year}"></h1>
+        <div th:each="field : ${reference.fields}">
+            <h1 th:text="${field} + ':'"></h1>   
+            <span th:text="${reference.getField(field)}"></span>
         </div>
     </body>
 </html>

--- a/src/main/resources/templates/reference.html
+++ b/src/main/resources/templates/reference.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+    <head>
+        <title>TODO supply a title</title>
+    </head>
+    <body>
+        <div>
+            <h1 th:text="${reference.author}"></h1>   
+            <h1 th:text="${reference.title}"></h1>
+            <h1 th:text="${reference.publisher}"></h1>
+            <h1 th:text="${reference.year}"></h1>
+            <!-- <h1 th:text="${reference.category}"></h1>-->
+        </div>
+    </body>
+</html>

--- a/src/main/resources/templates/reference.html
+++ b/src/main/resources/templates/reference.html
@@ -9,7 +9,6 @@
             <h1 th:text="${reference.title}"></h1>
             <h1 th:text="${reference.publisher}"></h1>
             <h1 th:text="${reference.year}"></h1>
-            <!-- <h1 th:text="${reference.category}"></h1>-->
         </div>
     </body>
 </html>

--- a/src/main/resources/templates/referenceList.html
+++ b/src/main/resources/templates/referenceList.html
@@ -1,5 +1,32 @@
-<h1 th:text="${referenceList.name}"></h1>
-<!-- TODO: Fix error when the list is empty
-<ul>
-    <li th:each="reference : ${referenceList}" th:text="${reference.title}"></li>
-</ul>-->
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+    <head>
+        <title>Reference lists</title>
+        <meta charset="UTF-8"></meta>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
+    </head>
+    <body>
+        <div>
+            <h1 th:text="${referenceList.name}"></h1>
+
+            <ul>
+                <li th:each="reference : ${referenceList.references}">
+                    <span th:text="${reference.title}"></span>
+                </li>
+            </ul>
+        </div>
+        <div>
+            <div>
+                <span th:if="${#lists.isEmpty(references)}">No references in the database at the moment for you to add</span>
+                <span th:if="${not #lists.isEmpty(references)}">Add a reference:</span>
+                
+                <form  th:if="${not #lists.isEmpty(references)}" th:action="@{/referencelists/{referenceListId}/references/(referenceListId=${referenceList.id})}" method="POST">
+                    <select name="referenceId">
+                        <option th:each="reference : ${references}" th:value="${reference.id}" th:text="${reference.title}"></option>
+                    </select>
+                    <p><input type="submit" value="add reference"/></p>
+                </form>
+            </div>
+        </div>
+    </body>
+</html>

--- a/src/main/resources/templates/reference_choose.html
+++ b/src/main/resources/templates/reference_choose.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+    <head>
+        <title>TODO supply a title</title>
+        <meta charset="UTF-8"></meta>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
+    </head>
+    <body>
+        <div>
+            <h1>Choose the type of reference you want to make:</h1>
+            <ul>
+                <li><a th:href="@{/references/bookreferences/new}">Book reference</a></li>
+            </ul>
+        </div>
+    </body>
+</html>

--- a/src/main/resources/templates/reference_choose.html
+++ b/src/main/resources/templates/reference_choose.html
@@ -10,6 +10,7 @@
             <h1>Choose the type of reference you want to make:</h1>
             <ul>
                 <li><a th:href="@{/references/bookreferences/new}">Book reference</a></li>
+                <li><a th:href="@{/references/articlereferences/new}">Article reference</a></li>
             </ul>
         </div>
     </body>

--- a/src/main/resources/templates/reference_new.html
+++ b/src/main/resources/templates/reference_new.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+    <head>
+        <title>Create a new reference</title>
+        <meta charset="UTF-8"></meta>
+    </head>
+    <body>
+        <div>
+            <h1>Create a new reference</h1>
+            
+            <form action="#" th:action="@{new}" th:object="${reference}" method="post">
+                Author<br/>                
+                <input type="text" name="author"/><br/>                
+                Title<br/> 
+                <input type="text" name="title"/><br/>
+                Publisher:<br/> 
+                <input type="text" name="publisher"/><br/>
+                Year:<br/> 
+                <input type="text" name="year"/><br/>
+                <input type="submit" value="Submit"/>
+                
+            </form>
+            
+        </div>
+    </body>
+</html>

--- a/src/main/resources/templates/reference_new.html
+++ b/src/main/resources/templates/reference_new.html
@@ -7,20 +7,17 @@
     <body>
         <div>
             <h1>Create a new reference</h1>
-            
-            <form action="#" th:action="@{new}" th:object="${reference}" method="post">
-                Author<br/>                
-                <input type="text" name="author"/><br/>                
-                Title<br/> 
-                <input type="text" name="title"/><br/>
-                Publisher:<br/> 
-                <input type="text" name="publisher"/><br/>
-                Year:<br/> 
-                <input type="text" name="year"/><br/>
+
+            <form action="#" th:action="@{/references/{reference-type}/new/(reference-type=${referenceType})}" th:object="${reference}" method="post">
+                <p th:each="field : ${reference.fields}">
+                    <span th:text="${field} + ':'"></span><br/>
+                    <input type="text" th:name="${field}"/><br/>                       
+                </p>
+
                 <input type="submit" value="Submit"/>
-                
             </form>
-            
+            <!-- th:action="@{/referencelists/{referenceListId}/references/(referenceListId=${referenceList.id})} -->
+
         </div>
     </body>
 </html>


### PR DESCRIPTION
Created a separate repository for a subclass of Reference since single table inheritance doesn't seem to function well with only one repository for them all. Also had to add @Entity annotation to the subclass.

You can now add references. First you go to /references/new, from which you choose which type of reference you want to add and click the corresponding link, and then you fill out the information for the reference.

You can also see any existing references of a list in the list's page and add new ones to it.

You can add both article and book references now. To avoid having to make a view of its own for each domain object class, the classes have a list of their field names as strings. It's not the prettiest solution, but works.