### PR TITLE
Validation for empty mandatory fields for references

### DIFF
--- a/src/main/java/ohtuhatut/controller/ReferenceController.java
+++ b/src/main/java/ohtuhatut/controller/ReferenceController.java
@@ -1,4 +1,3 @@
-
 package ohtuhatut.controller;
 
 import ohtuhatut.domain.ArticleReference;
@@ -9,6 +8,7 @@ import ohtuhatut.service.ReferenceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,7 +17,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 /**
  * Controller for handling references
- * 
+ *
  * @author tuomokar
  */
 @Controller
@@ -28,34 +28,42 @@ public class ReferenceController {
     private ReferenceService referenceService;
 
     @RequestMapping(value = "/new", method = RequestMethod.GET)
-    public String newReference(Model model){        
+    public String newReference(Model model) {
         return "reference_choose";
     }
-    
+
     // works for all kind of references
     @RequestMapping(value = "/{id}", method = RequestMethod.GET)
-    public String getReference(Model model, @PathVariable Long id){     
+    public String getReference(Model model, @PathVariable Long id) {
         model.addAttribute("reference", referenceService.getReference(id));
         return "reference";
     }
-    
+
     // -------------- book references
     @RequestMapping(value = "/bookreferences/new", method = RequestMethod.GET)
-    public String newBookReference(Model model){;
+    public String newBookReference(Model model) {;
         model.addAttribute("reference", new BookReference());
         model.addAttribute("referenceType", "bookreferences");
         return "reference_new";
     }
-    
+
     @RequestMapping(value = "/bookreferences/new", method = RequestMethod.POST)
-    public String newBookReferenceCreate(@ModelAttribute BookReference reference, RedirectAttributes attr) {
+    public String newBookReferenceCreate(@ModelAttribute BookReference reference, RedirectAttributes attr,
+            Model model) {
+
+        if (!reference.getEmptyMandatoryFields().isEmpty()) {
+            model.addAttribute("emptyFields", referenceService.getErrorMessages(reference.getEmptyMandatoryFields()));
+            model.addAttribute("reference", new BookReference());
+            model.addAttribute("referenceType", "bookreferences");
+            return "reference_new";
+        }
         referenceService.saveBookReference(reference);
-        
+
         attr.addAttribute("id", reference.getId());
         return "redirect:/references/{id}";
     }
     // <-- book references
-    
+
     // -------------- article references
     @RequestMapping(value = "/articlereferences/new", method = RequestMethod.GET)
     public String newArticleReference(Model model) {
@@ -63,54 +71,72 @@ public class ReferenceController {
         model.addAttribute("referenceType", "articlereferences");
         return "reference_new";
     }
-    
+
     @RequestMapping(value = "/articlereferences/new", method = RequestMethod.POST)
-    public String newArticleReferenceCreate(@ModelAttribute ArticleReference reference, RedirectAttributes attr) {
+    public String newArticleReferenceCreate(@ModelAttribute ArticleReference reference, RedirectAttributes attr,
+            Model model) {
+        
+        if (!reference.getEmptyMandatoryFields().isEmpty()) {
+            model.addAttribute("emptyFields", referenceService.getErrorMessages(reference.getEmptyMandatoryFields()));
+            model.addAttribute("reference", new ArticleReference());
+            model.addAttribute("referenceType", "articlereferences");
+            return "reference_new";
+        }   
         referenceService.saveArticleReference(reference);
-       
+
         attr.addAttribute("id", reference.getId());
         return "redirect:/references/{id}";
     }
     // <-- article references
-    
+
     // -------------- booklet references
     @RequestMapping(value = "/bookletreferences/new", method = RequestMethod.GET)
-    public String newBookletReference(Model model){
+    public String newBookletReference(Model model) {
         model.addAttribute("reference", new BookletReference());
         model.addAttribute("referenceType", "bookletreferences");
         return "reference_new";
     }
-    
+
     @RequestMapping(value = "/bookletreferences/new", method = RequestMethod.POST)
-    public String newBookletReferenceCreate(@ModelAttribute BookletReference reference, RedirectAttributes attr) {
-        referenceService.saveBookletReference(reference);
+    public String newBookletReferenceCreate(@ModelAttribute BookletReference reference, RedirectAttributes attr,
+            Model model) {
         
+        if (!reference.getEmptyMandatoryFields().isEmpty()) {
+            model.addAttribute("emptyFields", referenceService.getErrorMessages(reference.getEmptyMandatoryFields()));
+            model.addAttribute("reference", new BookletReference());
+            model.addAttribute("referenceType", "bookletreferences");
+            return "reference_new";
+        }
+        referenceService.saveBookletReference(reference);
+
         attr.addAttribute("id", reference.getId());
         return "redirect:/references/{id}";
     }
     // <-- booklet references
-    
+
     // -------------- manual references
     @RequestMapping(value = "/manualreferences/new", method = RequestMethod.GET)
-    public String newManualReference(Model model){
+    public String newManualReference(Model model) {
         model.addAttribute("reference", new ManualReference());
         model.addAttribute("referenceType", "manualreferences");
         return "reference_new";
     }
-    
+
     @RequestMapping(value = "/manualreferences/new", method = RequestMethod.POST)
-    public String newManualReferenceCreate(@ModelAttribute ManualReference reference, RedirectAttributes attr) {
-        referenceService.saveManualReference(reference);
+    public String newManualReferenceCreate(@ModelAttribute ManualReference reference, RedirectAttributes attr,
+            Model model) {
         
+        if (!reference.getEmptyMandatoryFields().isEmpty()) {
+            model.addAttribute("emptyFields", referenceService.getErrorMessages(reference.getEmptyMandatoryFields()));
+            model.addAttribute("reference", new ManualReference());
+            model.addAttribute("referenceType", "manualreferences");
+            return "reference_new";
+        }
+        referenceService.saveManualReference(reference);
+
         attr.addAttribute("id", reference.getId());
         return "redirect:/references/{id}";
     }
     // <-- manual references
-    
-    
-    
+
 }
-
-
-
-   

--- a/src/main/java/ohtuhatut/domain/Reference.java
+++ b/src/main/java/ohtuhatut/domain/Reference.java
@@ -15,34 +15,37 @@ import org.hibernate.annotations.DiscriminatorOptions;
 import org.springframework.data.jpa.domain.AbstractPersistable;
 
 /**
- * The base Reference class that includes whatever fields necessary to support categories;
- * the said categories will decide which fields are mandatory/optional
- * 
+ * The base Reference class that includes whatever fields necessary to support
+ * categories; the said categories will decide which fields are
+ * mandatory/optional
+ *
  * @author matoking
+ * @author tuomokar
  */
 @Entity
 @Inheritance
-@DiscriminatorColumn(name="category")
+@DiscriminatorColumn(name = "category")
 @DiscriminatorValue("generic")
-@DiscriminatorOptions(force=true)
+@DiscriminatorOptions(force = true)
 @Table(name = "Reference")
 public class Reference extends AbstractPersistable<Long> {
+
     @Transient
     protected String type;
-    
+
     protected String author;
     protected String title;
     protected String publisher;
-    protected Integer year;  
+    protected Integer year;
     protected String journal;
     protected String volume;
-    
+
     @Transient
     protected List<String> mandatoryFields;
-    
+
     @Transient
     protected List<String> optionalFields;
-    
+
     // Fields = mandatory + optional fields
     @Transient
     protected List<String> fields;
@@ -55,59 +58,82 @@ public class Reference extends AbstractPersistable<Long> {
         fields = new ArrayList<String>(mandatoryFields);
         fields.addAll(optionalFields);
     }
-    
+
     /**
      * Get the value of the named field
-     * 
-     * @return The value of the field as String
-     *         If field doesn't belong to this reference type, null is returned
+     *
+     * @return The value of the field as String. If field doesn't belong to this
+     * reference type, null is returned
      */
     public String getField(String field) {
         if (!fields.contains(field)) {
             return null;
         }
-        
+
         switch (field) {
             case "author":
                 return getAuthor();
-                
+
             case "title":
                 return getTitle();
-                
+
             case "journal":
                 return getJournal();
-                
+
             case "volume":
                 return getVolume();
-                
+
             case "year":
                 return "" + getYear();
-                
+
             case "publisher":
                 return getPublisher();
-                
+
             default:
                 return null;
         }
     }
-    
+
     /**
      * Get a map of field and value pairs
-     * 
-     * @return Map of field and value pairs
-     *         Optional fields that are empty are omitted
+     *
+     * @return Map of field and value pairs Optional fields that are empty are
+     * omitted
      */
     public Map<String, String> getValueMap() {
         HashMap<String, String> valueMap = new HashMap<String, String>();
-        
+
         for (String field : getFields()) {
             String value = getField(field);
             if (value != null) {
                 valueMap.put(field, value);
-            } 
+            }
         }
-        
+
         return valueMap;
+    }
+
+    /**
+     * Checks if any mandatory field is empty, and if there are any such, 
+     * returns those empty fields. The year variable is an integer, so
+     * for that there is a null check if it in the list of the mandatory 
+     * attributes. Note that the first null check isn't enough to check for 
+     * the integer, because the getField method returns it as a string
+     * 
+     * @return list of empty fields
+     */
+    public List<String> getEmptyMandatoryFields() {
+        List<String> emptyFields = new ArrayList<>();
+
+        getMandatoryFields().stream().forEach((field) -> {
+            String value = getField(field);
+            
+            if (value == null || value.isEmpty() || (field.equals("year") && year == null)) {
+                emptyFields.add(field);
+            }
+        });
+        
+        return emptyFields;
     }
 
     public List<String> getOptionalFields() {
@@ -125,7 +151,7 @@ public class Reference extends AbstractPersistable<Long> {
     public void setFields(List<String> fields) {
         this.fields = fields;
     }
-    
+
     public List<String> getMandatoryFields() {
         return mandatoryFields;
     }
@@ -149,7 +175,7 @@ public class Reference extends AbstractPersistable<Long> {
     public String getVolume() {
         return volume;
     }
-    
+
     public String getAuthor() {
         return author;
     }
@@ -180,7 +206,7 @@ public class Reference extends AbstractPersistable<Long> {
 
     public void setYear(Integer year) {
         this.year = year;
-    } 
+    }
 
     public String getType() {
         return type;
@@ -189,6 +215,5 @@ public class Reference extends AbstractPersistable<Long> {
     public void setType(String type) {
         this.type = type;
     }
-    
-    
+
 }

--- a/src/main/java/ohtuhatut/service/ReferenceService.java
+++ b/src/main/java/ohtuhatut/service/ReferenceService.java
@@ -10,6 +10,7 @@ import java.util.List;
 /**
  * @author sofiak
  * @author iilumme
+ * @author tuomokar
  */
 
 @Service
@@ -48,6 +49,49 @@ public class ReferenceService {
 
     public void saveManualReference(ManualReference reference) {
         manualReferenceRepository.save(reference);
+    }
+    
+    /**
+     * Receives a list of empty mandatory fields in a reference and
+     * returns an error message listing the empty fields. If there are no
+     * empty fields, a null value is returned.
+     * 
+     * @param emptyFields list of empty fields in a reference
+     * @return error messages
+     */
+    public String getErrorMessages(List<String> emptyFields) {
+        if (emptyFields.isEmpty()) {
+            return null;
+        } else if (emptyFields.size() == 1) {
+            return oneFieldEmptyMessage(emptyFields);
+        } else if (emptyFields.size() == 2) {
+            return twoFieldsEmptyMessage(emptyFields);
+        }
+
+        return threeOrMoreFieldsEmptyMessage(emptyFields);
+    }
+    
+    private String threeOrMoreFieldsEmptyMessage(List<String> emptyFields) {
+        StringBuilder sb = new StringBuilder();
+        
+        int i = 0;
+        while (i < emptyFields.size() - 2) {
+            sb.append(emptyFields.get(i) + ", ");
+            i++;
+        }
+
+        sb.append(emptyFields.get(i));
+        sb.append(" and " + emptyFields.get(i + 1) + " are empty!");
+
+        return sb.toString();
+    }
+    
+    private String oneFieldEmptyMessage(List<String> emptyFields) {
+        return emptyFields.get(0) + " is empty!";
+    }
+    
+    private String twoFieldsEmptyMessage(List<String> emptyFields) {
+        return emptyFields.get(0) + " and " + emptyFields.get(1) + " are empty!";
     }
 
 }

--- a/src/main/resources/templates/reference_new.html
+++ b/src/main/resources/templates/reference_new.html
@@ -9,6 +9,8 @@
         <div>
             <h1>Create a new reference</h1>
 
+            <p th:if="${emptyFields != null}" th:text="${emptyFields}"></p>
+
             <form action="#" th:action="@{/references/{reference-type}/new/(reference-type=${referenceType})}" th:object="${reference}" method="post">
                 <p th:each="field : ${reference.fields}">
                     <span th:if="${#lists.contains(reference.mandatoryFields, field)}">*</span><span th:text="${field} + ':'"></span><br/>

--- a/src/test/java/ohtuhatut/domain/ReferenceTest.java
+++ b/src/test/java/ohtuhatut/domain/ReferenceTest.java
@@ -1,0 +1,36 @@
+package ohtuhatut.domain;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ *
+ * @author tuomokar
+ */
+public class ReferenceTest {
+
+    @Test
+    public void gettingEmptyFieldsWorksWithOneEmptyOrNullField() {
+        Reference ref = new BookReference();
+        ref.setAuthor("author1");
+        ref.setTitle("title1");
+        ref.setPublisher("publisher1");
+
+        assertTrue(ref.getEmptyMandatoryFields().size() == 1);
+        assertTrue(ref.getEmptyMandatoryFields().contains("year"));
+    }
+
+    @Test
+    public void gettingEmptyFieldsWorksWhenAllFieldsAreEmpty() {
+        Reference ref = new ArticleReference();
+
+        assertTrue(ref.getEmptyMandatoryFields().size() == ref.getMandatoryFields().size());
+        assertTrue(ref.getEmptyMandatoryFields().contains("author"));
+        assertTrue(ref.getEmptyMandatoryFields().contains("title"));
+        assertTrue(ref.getEmptyMandatoryFields().contains("journal"));
+        assertTrue(ref.getEmptyMandatoryFields().contains("year"));
+        assertTrue(ref.getEmptyMandatoryFields().contains("volume"));
+
+    }
+
+}

--- a/src/test/java/ohtuhatut/selenium/ReferenceTest.java
+++ b/src/test/java/ohtuhatut/selenium/ReferenceTest.java
@@ -109,6 +109,24 @@ public class ReferenceTest extends FluentTest {
                
         assertTrue(pageSource().contains("testTitle"));
     }
+    
+    @Test
+    public void articleReferenceCreationGivesErrorMessageWhenValidFieldsAreLeftEmpty() {
+        getToArticleReferenceCreationPage();
+        
+        submit(find("form").first());
+               
+        assertTrue(pageSource().contains("author, title, journal, year and volume are empty!"));
+    }
+    
+    @Test
+    public void manualReferenceCreationGivesErrorMessageWhenValidFieldsAreLeftEmpty() {
+        getToManualReferenceCreationPage();
+        
+        submit(find("form").first());
+               
+        assertTrue(pageSource().contains("title is empty!"));
+    }
 
     private void getToReferenceCreationsChoosingPage() {
         goTo(getUrl());

--- a/src/test/java/ohtuhatut/service/ReferenceServiceTest.java
+++ b/src/test/java/ohtuhatut/service/ReferenceServiceTest.java
@@ -1,0 +1,82 @@
+package ohtuhatut.service;
+
+import java.util.ArrayList;
+import ohtuhatut.Main;
+import ohtuhatut.domain.ArticleReference;
+import ohtuhatut.domain.BookReference;
+import ohtuhatut.domain.Reference;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ *
+ * @author tuomokar
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = Main.class)
+public class ReferenceServiceTest {
+
+    @Autowired
+    private ReferenceService referenceService;
+
+    public ReferenceServiceTest() {
+    }
+
+    @Test
+    public void errorMessageIsCorrectWithOneEmptyField() {
+        Reference ref = new BookReference();
+        ref.setAuthor("");
+        ref.setTitle("title1");
+        ref.setPublisher("publisher1");
+        ref.setYear(1900);
+
+        assertEquals("author is empty!", referenceService.getErrorMessages(ref.getEmptyMandatoryFields()));
+    }
+
+    @Test
+    public void errorMessageIsCorrectWithTwoEmptyFields() {
+        Reference ref = new ArticleReference();
+        ref.setAuthor("");
+        ref.setTitle("");
+        ref.setJournal("journal1");
+        ref.setVolume("vol1");
+        ref.setYear(2001);
+
+        assertEquals("author and title are empty!", referenceService.getErrorMessages(ref.getEmptyMandatoryFields()));
+    }
+
+    @Test
+    public void errorMessageIsCorrectWithThreeEmptyFields() {
+        Reference ref = new BookReference();
+        ref.setAuthor("");
+        ref.setTitle("");
+        ref.setPublisher("");
+        ref.setYear(1900);
+
+        assertEquals("author, title and publisher are empty!", referenceService.getErrorMessages(ref.getEmptyMandatoryFields()));
+    }
+
+    @Test
+    public void errorMessageIsCorrectWithOverThreeEmptyFields() {
+        Reference ref = new BookReference();
+        ref.setAuthor("");
+        ref.setTitle("");
+        ref.setPublisher("");
+        ref.setYear(null);
+
+        assertEquals("author, title, publisher and year are empty!", referenceService.getErrorMessages(ref.getEmptyMandatoryFields()));
+    }
+
+    @Test
+    public void nullIsReturnedIfEmptyListIsGiven() {
+        assertNull(referenceService.getErrorMessages(new ArrayList<>()));
+    }
+
+}


### PR DESCRIPTION
The normal Spring annotations such as `@NotEmpty` could not be used as the attributes are in the superclass and implementing the annotations would check the fields for every type of reference ignoring if the reference really needs it.

Because and instead of that, I gave Reference a method to get any empty or null mandatory fields, and use that to check if the reference has any errors when being created. If the list is empty, there are no errors. If there are errors, i.e. the list has some fields, then the list is passed to ReferenceService which gives the appropriate error messages (e.g. "*author is empty!*" or "*author and title are empty!*" or "*author, title and year are empty!*". The error message is then added to the model and shown in the view.

This way probably isn't the prettiest possible, especially in the controllers as you need to add the error message along with the other info the view needs in each method that is handling the HTTP POST request with the new reference info. But it works at least.