### PR TITLE
Force user to give a key to a reference

### DIFF
--- a/src/main/java/ohtuhatut/domain/Reference.java
+++ b/src/main/java/ohtuhatut/domain/Reference.java
@@ -33,6 +33,8 @@ public class Reference extends AbstractPersistable<Long> {
     @Transient
     protected String type;
 
+    protected String key;
+    
     protected String author;
     protected String title;
     protected String booktitle;
@@ -52,22 +54,29 @@ public class Reference extends AbstractPersistable<Long> {
     protected List<String> fields;
 
     /**
-     * Create the list 'fields' which contains both mandatory and optional
+     * Create the list 'fields' which contains both mandatory and optional.
+     * The key value is added to the list of mandatory fields after populating
+     * the 'fields' list, as we don't want it to go the bibtex file along
+     * with the other values, but only as the key of the reference
      * fields
      */
     protected void populateFields() {
         fields = new ArrayList<String>(mandatoryFields);
         fields.addAll(optionalFields);
+        mandatoryFields.add("key");
     }
 
     /**
      * Get the value of the named field
      *
      * @return The value of the field as String. If field doesn't belong to this
-     * reference type, null is returned
+     * reference type, null is returned. The field 'key' is returned always
+     * as every reference has it but it's not within the list of all the fields
+     * so there's a separate check for it at the start.
      */
     public String getField(String field) {
-        if (!fields.contains(field)) {
+        
+        if (!fields.contains(field) && !field.equals("key")) {
             return null;
         }
 
@@ -92,6 +101,10 @@ public class Reference extends AbstractPersistable<Long> {
 
             case "publisher":
                 return getPublisher();
+              
+            case "key":
+                return getKey();
+                
 
             default:
                 return null;
@@ -105,7 +118,7 @@ public class Reference extends AbstractPersistable<Long> {
      * omitted
      */
     public Map<String, String> getValueMap() {
-        HashMap<String, String> valueMap = new HashMap<String, String>();
+        HashMap<String, String> valueMap = new HashMap<>();
 
         for (String field : getFields()) {
             String value = getField(field);
@@ -226,6 +239,14 @@ public class Reference extends AbstractPersistable<Long> {
 
     public void setType(String type) {
         this.type = type;
+    }
+    
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
     }
 
 }

--- a/src/main/java/ohtuhatut/service/ReferenceFormatService.java
+++ b/src/main/java/ohtuhatut/service/ReferenceFormatService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 /**
  *
  * @author matoking
+ * @author tuomokar
  */
 @Service
 public class ReferenceFormatService {
@@ -44,10 +45,9 @@ public class ReferenceFormatService {
     }
     
     private BibTeXEntry getBibTeXEntry(Reference reference) {
-        // TODO: Each entry contains a key used to cite or cross-reference the entry
-        // For now, put title as that key
+
         BibTeXEntry bibEntry = new BibTeXEntry(getTypeKey(reference.getType()),
-                                               new Key(reference.getField("title")));
+                                               new Key(reference.getKey()));
         
         for (Map.Entry<String, String> entry : reference.getValueMap().entrySet()) {
             // TODO: Numbers (eg. year of publication) should not be quoted

--- a/src/main/resources/templates/reference_new.html
+++ b/src/main/resources/templates/reference_new.html
@@ -5,20 +5,24 @@
         <meta charset="UTF-8"></meta>
     </head>
     <body>
-    <div th:replace="fragments/navbar :: navbar">Navbar</div>
+        <div th:replace="fragments/navbar :: navbar">Navbar</div>
         <div>
             <h1>Create a new reference</h1>
 
             <p th:if="${emptyFields != null}" th:text="${emptyFields}"></p>
 
             <form action="#" th:action="@{/references/{reference-type}/new/(reference-type=${referenceType})}" th:object="${reference}" method="post">
+                <p>
+                    <span>*Key:</span><br/>
+                    <input id="key" name="key"/>
+                </p>
                 <p th:each="field : ${reference.fields}">
                     <span th:if="${#lists.contains(reference.mandatoryFields, field)}">*</span><span th:text="${field} + ':'"></span><br/>
 
                     <input th:if="${field =='year'}" th:id="${field}" type="number" th:name="${field}"/><br/>
                     <input th:if="${field !='year'}" th:id="${field}" type="text" th:name="${field}"/><br/>
                 </p>
-                
+
                 <p>Fields marked with * are mandatory.</p>
 
                 <input type="submit" value="Submit"/>

--- a/src/main/resources/templates/referencelist_show.html
+++ b/src/main/resources/templates/referencelist_show.html
@@ -1,45 +1,47 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>Reference lists</title>
-    <meta charset="UTF-8"></meta>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
-</head>
-<body>
-<div th:replace="fragments/navbar :: navbar">Navbar</div>
-<div>
-    <h1 th:text="${referenceList.name}"></h1>
+    <head>
+        <title>Reference lists</title>
+        <meta charset="UTF-8"></meta>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
+    </head>
+    <body>
+        <div th:replace="fragments/navbar :: navbar">Navbar</div>
+        <div>
+            <h1 th:text="${referenceList.name}"></h1>
 
-    <ul>
-        <li th:each="reference : ${referenceList.references}">
-            <span th:text="${reference.title}"></span>
-        </li>
-    </ul>
-</div>
-<div>
-    <div>
-        <span th:if="${#lists.isEmpty(references) or #lists.containsAll(referenceList.references, references)}">No references in the database at the moment for you to add</span>
-        <div th:if="${not #lists.isEmpty(references)}">
-            <span th:if="${not #lists.containsAll(referenceList.references, references)}">Add a reference:</span>
-
-            <form th:if="${not #lists.containsAll(referenceList.references, references)}"
-                  th:action="@{/referencelists/{referenceListId}/references/(referenceListId=${referenceList.id})}"
-                  method="POST">
-                <select name="referenceId" id="references">
-                    <option th:each="reference : ${references}"
-                            th:if="${not #lists.contains(referenceList.references, reference)}"
-                            th:value="${reference.id}" th:text="${reference.title}"></option>
-                </select>
-                <p><input type="submit" value="add reference"/></p>
-            </form>
+            <ul>
+                <li th:each="reference : ${referenceList.references}">
+                    <span th:text="${reference.title}"></span>
+                </li>
+            </ul>
         </div>
-        <p th:if="${not #lists.isEmpty(referenceList.references)}">
-        <form th:id="export" th:action="@{/referencelists/{referenceListId}/export(referenceListId=${referenceList.id})}" method="GET">
-            <input type="text" th:id="name" th:name="name"/>
-            <input type="submit" value="Export references"/>
-        </form>
-        </p>
-    </div>
-</div>
-</body>
+        <div>
+            <div>
+                <span th:if="${#lists.isEmpty(references) or #lists.containsAll(referenceList.references, references)}">No references in the database at the moment for you to add</span>
+                <div th:if="${not #lists.isEmpty(references)}">
+                    <span th:if="${not #lists.containsAll(referenceList.references, references)}">Add a reference:</span>
+
+                    <form th:if="${not #lists.containsAll(referenceList.references, references)}"
+                          th:action="@{/referencelists/{referenceListId}/references/(referenceListId=${referenceList.id})}"
+                          method="POST">
+
+                        <select name="referenceId" id="references">
+                            <option th:each="reference : ${references}"
+                                    th:if="${not #lists.contains(referenceList.references, reference)}"
+                                    th:value="${reference.id}" th:text="${reference.title}"></option>
+                        </select>
+
+                        <p><input type="submit" value="add reference"/></p>             
+                    </form>
+                </div>
+                <div th:if="${not #lists.isEmpty(referenceList.references)}">
+                    <form th:id="export" th:action="@{/referencelists/{referenceListId}/export(referenceListId=${referenceList.id})}" method="GET">
+                        <input type="text" th:id="name" th:name="name"/>
+                        <input type="submit" value="Export references"/>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </body>
 </html>

--- a/src/test/java/ohtuhatut/controller/ReferenceControllerTest.java
+++ b/src/test/java/ohtuhatut/controller/ReferenceControllerTest.java
@@ -99,7 +99,8 @@ public class ReferenceControllerTest {
                 .param("author", "tester")
                 .param("title", "test")
                 .param("publisher", "testingplace")
-                .param("year", "2016"));
+                .param("year", "2016")
+                .param("key", "key1"));
 
         assertTrue(bookReferenceRepository.count() == 1);
 
@@ -137,7 +138,8 @@ public class ReferenceControllerTest {
                 .param("title", "test")
                 .param("journal", "testingplace")
                 .param("volume","1")
-                .param("year", "2016"));
+                .param("year", "2016")
+                .param("key", "key2"));
 
         assertTrue(articleReferenceRepository.count() == 1);
 
@@ -171,7 +173,8 @@ public class ReferenceControllerTest {
     public void postRequestToBookletreferencesNewSavesABookletreferenceToDatabase() throws Exception {
 
         mockMvc.perform(post(API_URI + "/bookletreferences/new")
-                .param("title", "test"));
+                .param("title", "test")
+                .param("key", "key3"));
 
         assertTrue(bookletReferenceRepository.count() == 1);
 
@@ -201,7 +204,8 @@ public class ReferenceControllerTest {
     public void postRequestToManualreferencesNewSavesAManualreferenceToDatabase() throws Exception {
 
         mockMvc.perform(post(API_URI + "/manualreferences/new")
-                .param("title", "test"));
+                .param("title", "test")
+                .param("key", "key4"));
 
         assertTrue(manualReferenceRepository.count() == 1);
 
@@ -234,7 +238,8 @@ public class ReferenceControllerTest {
                 .param("author", "testAuthor")
                 .param("booktitle", "book")
                 .param("year", "2016")
-                .param("title", "test"));
+                .param("title", "test")
+                .param("key", "key5"));
 
         assertTrue(inproceedingsReferenceRepository.count() == 1);
 
@@ -254,7 +259,9 @@ public class ReferenceControllerTest {
                 .param("title", "testauthor")
                 .param("title", "test")
                 .param("publisher", "testingplace")
-                .param("year", "yeah"));
+                .param("year", "yeah")
+                .param("key", "key6"));
+                
 
         assertTrue(bookReferenceRepository.count() == 0);
 

--- a/src/test/java/ohtuhatut/domain/ReferenceTest.java
+++ b/src/test/java/ohtuhatut/domain/ReferenceTest.java
@@ -19,8 +19,9 @@ public class ReferenceTest {
         ref.setTitle("title1");
         ref.setPublisher("publisher1");
 
-        assertTrue(ref.getEmptyMandatoryFields().size() == 1);
+        assertTrue(ref.getEmptyMandatoryFields().size() == 2);
         assertTrue(ref.getEmptyMandatoryFields().contains("year"));
+        assertTrue(ref.getEmptyMandatoryFields().contains("key"));
     }
 
     @Test
@@ -33,6 +34,7 @@ public class ReferenceTest {
         assertTrue(ref.getEmptyMandatoryFields().contains("journal"));
         assertTrue(ref.getEmptyMandatoryFields().contains("year"));
         assertTrue(ref.getEmptyMandatoryFields().contains("volume"));
+        assertTrue(ref.getEmptyMandatoryFields().contains("key"));
 
     }
 
@@ -48,11 +50,12 @@ public class ReferenceTest {
     public void gettingMandatoryFieldsWorks() {
         Reference ref = new BookReference();
 
-        assertTrue(ref.getMandatoryFields().size() == 4);
+        assertTrue(ref.getMandatoryFields().size() == 5);
         assertTrue(ref.getMandatoryFields().contains("author"));
         assertTrue(ref.getMandatoryFields().contains("title"));
         assertTrue(ref.getMandatoryFields().contains("publisher"));
         assertTrue(ref.getMandatoryFields().contains("year"));
+        assertTrue(ref.getMandatoryFields().contains("key"));
     }
 
     @Test
@@ -91,6 +94,42 @@ public class ReferenceTest {
 
         assertTrue(ref.getFields().size() == 1);
         assertTrue(ref.getFields().contains("testField"));
+    }
+    
+    @Test
+    public void keyIsNotInTheListOfAllFields() {
+        Reference ref = new BookletReference();
+        List<String> fields = new ArrayList<>();
+
+        fields.add("testField");
+        ref.setFields(fields);
+
+        assertTrue(ref.getFields().size() == 1);
+        assertTrue(!ref.getFields().contains("key"));
+    }
+    
+    @Test
+    public void keyIsNotInTheListOfOptionalFields() {
+        Reference ref = new BookletReference();
+        List<String> fields = new ArrayList<>();
+
+        fields.add("testField");
+        ref.setOptionalFields(fields);
+
+        assertTrue(ref.getOptionalFields().size() == 1);
+        assertTrue(!ref.getOptionalFields().contains("key"));
+    }
+    
+    @Test
+    public void keyIsNotInTheListOfMandatoryFieldsAfterSettingTheMandatoryFields() {
+        Reference ref = new BookletReference();
+        List<String> fields = new ArrayList<>();
+
+        fields.add("testField");
+        ref.setMandatoryFields(fields);
+
+        assertTrue(ref.getMandatoryFields().size() == 1);
+        assertTrue(!ref.getMandatoryFields().contains("key"));
     }
 
 }

--- a/src/test/java/ohtuhatut/selenium/ReferenceListTest.java
+++ b/src/test/java/ohtuhatut/selenium/ReferenceListTest.java
@@ -91,7 +91,7 @@ public class ReferenceListTest extends FluentTest {
     
     @Test
     public void addingReferencesToAReferenceListIsSuccessful() {
-        createAReference();
+        createAReference(1);
         createAReferenceList();
         
         fillSelect("#references").withIndex(0);
@@ -104,7 +104,7 @@ public class ReferenceListTest extends FluentTest {
     
     @Test
     public void linkToExportReferencesAppearsIfReferenceListContainsReferences() {
-        createAReference();
+        createAReference(1);
         createAReferenceList();
         
         assertFalse(pageSource().contains("Export references"));
@@ -118,8 +118,8 @@ public class ReferenceListTest extends FluentTest {
     
     @Test
     public void exportingReferenceListOnlyExportsReferencesInTheList() {
-        createAReference();
-        createAReference();
+        createAReference(1);
+        createAReference(2);
         createAReferenceList();
         
         fillSelect("#references").withIndex(0);
@@ -163,10 +163,11 @@ public class ReferenceListTest extends FluentTest {
         submit(find("form").first());
     }
     
-    private void createAReference() {
+    private void createAReference(int i) {
         getToManualReferenceCreationPage();
 
         fill("#title").with("testTitle");
+        fill("#key").with("key" + i);
         submit(find("form").first());
     }
     

--- a/src/test/java/ohtuhatut/selenium/ReferenceTest.java
+++ b/src/test/java/ohtuhatut/selenium/ReferenceTest.java
@@ -64,6 +64,7 @@ public class ReferenceTest extends FluentTest {
         fill("#title").with("testTitle");
         fill("#publisher").with("testPublisher");
         fill("#year").with("2012");
+        fill("#key").with("key1");
         submit(find("form").first());       
 
         assertTrue(pageSource().contains("testAuthor"));
@@ -81,6 +82,7 @@ public class ReferenceTest extends FluentTest {
         fill("#journal").with("testJournal");
         fill("#year").with("2011");
         fill("#volume").with("testVolume");
+        fill("#key").with("key2");
         submit(find("form").first());
         
         assertTrue(pageSource().contains("testAuthor"));
@@ -95,6 +97,7 @@ public class ReferenceTest extends FluentTest {
         getToBookletReferenceCreationPage();
 
         fill("#title").with("testTitle");
+        fill("#key").with("key3");
         submit(find("form").first());      
 
         assertTrue(pageSource().contains("testTitle"));
@@ -105,6 +108,7 @@ public class ReferenceTest extends FluentTest {
         getToManualReferenceCreationPage();
 
         fill("#title").with("testTitle");
+        fill("#key").with("key4");
         submit(find("form").first());
                
         assertTrue(pageSource().contains("testTitle"));
@@ -118,6 +122,7 @@ public class ReferenceTest extends FluentTest {
         fill("#title").with("testTitle");
         fill("#booktitle").with("testBookTitle");
         fill("#year").with("2011");
+        fill("#key").with("key5");
         submit(find("form").first());
 
         assertTrue(pageSource().contains("testAuthor"));
@@ -132,7 +137,7 @@ public class ReferenceTest extends FluentTest {
         
         submit(find("form").first());
                
-        assertTrue(pageSource().contains("author, title, journal, year and volume are empty!"));
+        assertTrue(pageSource().contains("author, title, journal, year, volume and key are empty!"));
     }
 
 
@@ -142,7 +147,7 @@ public class ReferenceTest extends FluentTest {
 
         submit(find("form").first());
 
-        assertTrue(pageSource().contains("title is empty!"));
+        assertTrue(pageSource().contains("title and key are empty!"));
     }
 
     private void getToReferenceCreationsChoosingPage() {

--- a/src/test/java/ohtuhatut/service/ReferenceServiceTest.java
+++ b/src/test/java/ohtuhatut/service/ReferenceServiceTest.java
@@ -36,6 +36,7 @@ public class ReferenceServiceTest {
         ref.setTitle("title1");
         ref.setPublisher("publisher1");
         ref.setYear(1900);
+        ref.setKey("key1");
 
         assertEquals("author is empty!", referenceService.getErrorMessages(ref.getEmptyMandatoryFields()));
     }
@@ -48,6 +49,7 @@ public class ReferenceServiceTest {
         ref.setJournal("journal1");
         ref.setVolume("vol1");
         ref.setYear(2001);
+        ref.setKey("key2");
 
         assertEquals("author and title are empty!", referenceService.getErrorMessages(ref.getEmptyMandatoryFields()));
     }
@@ -59,6 +61,7 @@ public class ReferenceServiceTest {
         ref.setTitle("");
         ref.setPublisher("");
         ref.setYear(1900);
+        ref.setKey("key3");
 
         assertEquals("author, title and publisher are empty!", referenceService.getErrorMessages(ref.getEmptyMandatoryFields()));
     }
@@ -69,9 +72,11 @@ public class ReferenceServiceTest {
         ref.setAuthor("");
         ref.setTitle("");
         ref.setPublisher("");
+        ref.setKey("");
         ref.setYear(null);
+        
 
-        assertEquals("author, title, publisher and year are empty!", referenceService.getErrorMessages(ref.getEmptyMandatoryFields()));
+        assertEquals("author, title, publisher, year and key are empty!", referenceService.getErrorMessages(ref.getEmptyMandatoryFields()));
     }
 
     @Test


### PR DESCRIPTION
They bibtex reference key isn't stored in the list of all the fields, but only in the list of mandatory fields. This way it gets included in the error messages but does not go to the bibtex file as an attribute along with the others, but as the key of a reference like it should.

Do note though that it's not added to the list of mandatory fields at the same time the other mandatory fields are added, but instead it's done only after populating the list of all fields with the mandatory and optional fields (in order to prevent it from going to the list of all fields).