### PR TITLE
Reference key is unique

### DIFF
--- a/src/main/java/ohtuhatut/repository/ReferenceRepository.java
+++ b/src/main/java/ohtuhatut/repository/ReferenceRepository.java
@@ -1,6 +1,7 @@
 
 package ohtuhatut.repository;
 
+import java.util.List;
 import ohtuhatut.domain.Reference;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,5 +11,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * @author tuomokar
  */
 public interface ReferenceRepository extends JpaRepository<Reference, Long>  {
-    
+    List<Reference> findByKey(String key);
 }

--- a/src/main/java/ohtuhatut/service/ReferenceService.java
+++ b/src/main/java/ohtuhatut/service/ReferenceService.java
@@ -170,5 +170,75 @@ public class ReferenceService {
         return allTypes.get(type) == null;
     }
     
+    public boolean referenceKeyAlreadyUsed(String key) {
+        return !referenceRepository.findByKey(key).isEmpty();
+    }
+    
+    /**
+     * Returns an error message if key has already been used. If the key hasn't
+     * been used, then null is returned.
+     * 
+     * @param key A reference's Bibtex key
+     * @return error message if key has been used, or null if it has not been
+     * used
+     */
+    public String keyNotUniqueErrorMessage(String key) {
+        if (referenceKeyAlreadyUsed(key)) {
+            return "That key has already been used, please use another key";
+        }
+        return null;
+    }
+    
+    /**
+     * Returns an error message if a given reference's key is in use on some
+     * other reference. If it is not, then null is returned
+     * 
+     * @param reference a reference to be compared to
+     * @return error message if key has been used on some other reference, or 
+     * null if it has not been used
+     */
+    public String keyIsInUseOnSomeOtherReferenceErrorMessage(Reference reference) {
+        if (referenceKeyAlreadyUsedOnSomeOtherReference(reference)) {
+            return "That key is in use on another reference, please use another key";
+        }
+        return null;
+    }
+    
+    /**
+     * Checks if a key has already been used, and if it has, checks if the
+     * reference having that key is the same reference as the one given as the
+     * parameter. This method can be used for editing references - if the 
+     * reference is the same one, then it must be able to be resaved with the
+     * key it already has, and the check must be applied only to other
+     * references.
+     * 
+     * @param reference Reference to be compared to the ones in the database
+     * @return true if reference's key has been used on some other reference
+     * than the one received as the parameter. Otherwise false is returned.
+     */
+    public boolean referenceKeyAlreadyUsedOnSomeOtherReference(Reference reference) {
+        List<Reference> references = referenceRepository.findByKey(reference.getKey());       
+        
+        for (Reference ref : references) {
+            if (referencesAreTheSame(ref, reference)) {
+                continue;
+            }
+            
+            if (keysAreTheSame(ref.getKey(), reference.getKey())) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+    
+    private boolean referencesAreTheSame(Reference ref1, Reference ref2) {
+        return ref1.getId().equals(ref2.getId());
+    }
+    
+    private boolean keysAreTheSame(String key1, String key2) {
+        return key1.equals(key2);
+    }
+    
     
 }

--- a/src/main/resources/templates/references/reference_edit.html
+++ b/src/main/resources/templates/references/reference_edit.html
@@ -16,11 +16,15 @@
             <div class="alert alert-danger" th:if="${emptyFieldMessage != null}">
                 <p th:text="${emptyFieldMessage}"></p>
             </div>
+            
+            <div th:if="${keyUsed}" class="alert alert-danger">
+                <p th:text="${keyUsed}"></p>
+            </div>
 
             <form class="form-horizontal" action="#" th:action="@{/references/{id}/edit/(id=${reference.id})}" th:object="${reference}" method="post">
                 <div class="form-group">
                     <label for="key" class="col-sm-2 control-label">*Key:</label>
-                    <div class="col-sm-10" th:classappend="${emptyFields.contains('key')} ? 'has-error'">
+                    <div class="col-sm-10" th:classappend="${emptyFields.contains('key')} or ${keyUsed} ? 'has-error'">
                         <input class="form-control" type="text" id="key" name="key" th:value="${reference.key != null} ? ${reference.key} : ''"/>
                     </div>
                 </div>

--- a/src/main/resources/templates/references/reference_new.html
+++ b/src/main/resources/templates/references/reference_new.html
@@ -16,11 +16,15 @@
             <div th:if="${emptyFieldMessage}" class="alert alert-danger">
                 <p th:text="${emptyFieldMessage}"></p>
             </div>
+            
+            <div th:if="${keyUsed}" class="alert alert-danger">
+                <p th:text="${keyUsed}"></p>
+            </div>
 
             <form class="form-horizontal" action="#" th:action="@{/references/new/}" th:object="${reference}" method="post">
                 <div class="form-group">
                     <label for="key" class="col-sm-2 control-label">*Key:</label>
-                    <div class="col-sm-10" th:classappend="${emptyFields.contains('key')} ? 'has-error'">
+                    <div class="col-sm-10" th:classappend="${emptyFields.contains('key')} or ${keyUsed} ? 'has-error'">
                         <input class="form-control" id="key" name="key"/>
                     </div>
                 </div>

--- a/src/test/java/ohtuhatut/selenium/ReferenceTest.java
+++ b/src/test/java/ohtuhatut/selenium/ReferenceTest.java
@@ -223,17 +223,34 @@ public class ReferenceTest extends FluentTest {
         assertTrue(pageSource().contains("Please choose a type first"));
     }
             
-            /*
-            if (type == null || referenceService.typeIsNotKnown(type)) {
-            redirectAttr.addFlashAttribute("typeNotChosen", "Please choose a type first");
-            return "redirect:/references/choose";
-        }
-            */
+    @Test
+    public void tryingToGiveAKeyThatHasAlreadyBeenUsedGivesErrorMessage() {
+        createAReference(3);
+        createAReference(3);
+        
+        assertTrue(pageSource().contains("That key has already been used, please use another key"));
+    }
+    
+    @Test
+    public void tryingToGiveAnAlreadyUsedKeyAndLeavingMandatoryFieldsEmptyGivesErrorMessagesForBoth() {
+        createAReference(3);
+        tryToCreateReferenceWithoutTitle(3);
+        
+        assertTrue(pageSource().contains("That key has already been used, please use another key"));
+        assertTrue(pageSource().contains("title is empty"));
+    }    
 
     private void createAReference(int i) {
         getToManualReferenceCreationPage();
 
         fill("#title").with("testTitle");
+        fill("#key").with("key" + i);
+        submit(find("form").first());
+    }
+    
+    private void tryToCreateReferenceWithoutTitle(int i) {
+        getToManualReferenceCreationPage();
+        
         fill("#key").with("key" + i);
         submit(find("form").first());
     }
@@ -272,4 +289,5 @@ public class ReferenceTest extends FluentTest {
         getToReferenceCreationsChoosingPage();
         click(find("a", withText("Inproceedings reference")));
     }
+    
 }

--- a/src/test/java/ohtuhatut/service/ReferenceServiceTest.java
+++ b/src/test/java/ohtuhatut/service/ReferenceServiceTest.java
@@ -199,5 +199,98 @@ public class ReferenceServiceTest {
     public void theMethodTypeIsNotKnownReturnsFalseWhenGivingTheTypeOfAnArticleReference() {
         assertFalse(referenceService.typeIsNotKnown("article"));
     }
+    
+    @Test
+    public void tryingToFindAReferenceByKeyThatIsAlreadyUsedReturnsTrue() {
+        Reference ref = new Reference();
+        ref.setKey("key1");
+        
+        referenceService.saveReference(ref);
+        
+        assertTrue(referenceService.referenceKeyAlreadyUsed(ref.getKey()));   
+    }
+    
+    @Test
+    public void tryingToFindByReferenceByKeyThatHasNotBeenUsedReturnsFalse() {    
+        assertFalse(referenceService.referenceKeyAlreadyUsed("keyNotUsed"));   
+    }
+    
+    @Test
+    public void errorMessageIsReturnedCorrectlyWhenKeyHasBeenUsed() {
+        Reference ref = new Reference();
+        ref.setKey("key2");
+        
+        referenceService.saveReference(ref);
+        
+        assertEquals("That key has already been used, please use another key", 
+                referenceService.keyNotUniqueErrorMessage(ref.getKey()));
+    }
+    
+    @Test
+    public void errorMessageIsReturnedCorrectlyWhenKeyHasNotBeenUsed() {
+        assertNull(referenceService.keyNotUniqueErrorMessage("keyNotUsed"));
+    }
+    
+    @Test
+    public void tryingToFindByReferenceKeyUsedOnSomeOtherReferenceReturnsTrue() {
+        Reference ref1 = new Reference();
+        ref1.setKey("key3");
+        Reference ref2 = new Reference();
+        ref2.setKey("key4");
+        
+        referenceService.saveReference(ref1);
+        referenceService.saveReference(ref2);
+        
+        ref2.setKey("key3");
+        
+        assertTrue(referenceService.referenceKeyAlreadyUsedOnSomeOtherReference(ref2));
+    }
+    
+    @Test
+    public void tryingToFindByReferenceKeyThatIsNotUsedOnAnyOtherReferenceReturnsFalse() {
+        Reference ref1 = new Reference();
+        ref1.setKey("key5");
+        Reference ref2 = new Reference();
+        ref2.setKey("key6");
+        
+        referenceService.saveReference(ref1);
+        referenceService.saveReference(ref2);
+        
+        assertFalse(referenceService.referenceKeyAlreadyUsedOnSomeOtherReference(ref2));
+    }
+    
+    @Test
+    public void seeingIfAnyOtherReferenceHasTheSameKeyReturnsFalseWhenThereAreNoOtherReferences() {
+        Reference ref = new Reference();
+        ref.setKey("key7");
+
+        referenceService.saveReference(ref);
+        
+        assertFalse(referenceService.referenceKeyAlreadyUsedOnSomeOtherReference(ref));
+    }
+    
+    @Test
+    public void whenKeyIsInUseBySomeOtherReferenceTheErrorMessageIsReturned() {
+        Reference ref = new Reference();
+        ref.setKey("key8");
+        
+        referenceService.saveReference(ref);
+        
+        Reference ref2 = new Reference();
+        ref2.setKey("key8");
+        
+        assertEquals("That key is in use on another reference, please use another key", 
+                referenceService.keyIsInUseOnSomeOtherReferenceErrorMessage(ref2));
+    }
+    
+    @Test
+    public void whenKeyIsNotInUseByAnyOtherReferenceNullIsReturned() {
+        Reference ref = new Reference();
+        ref.setKey("key9");
+        
+        referenceService.saveReference(ref);
+        
+        assertNull(referenceService.keyIsInUseOnSomeOtherReferenceErrorMessage(ref));
+    }
 
 }


### PR DESCRIPTION
Shows the error message if user tries to give a key that is already in use when trying to create a new reference or when trying to edit a reference (in that case checks if some other reference has the given key so it can be left still).